### PR TITLE
Add Android networking scaffolding with checkout flow support

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,8 @@
+# Android networking + checkout building blocks
+
+Các khối mã Kotlin mẫu này giúp khởi tạo Retrofit/OkHttp với timeout, logging và interceptor auth, repository dùng Flow + retry/backoff và idempotency cho checkout, cùng với màn hình state chuẩn và telemetry Crashlytics/Logcat.
+
+## Thành phần chính
+- `network`: `NetworkModule` tạo `OkHttpClient` (timeout, logging, auth) và `Retrofit`; `CheckoutService` định nghĩa API checkout.
+- `data`: `CheckoutRepository` dùng Flow, ánh xạ lỗi sang `DomainError`, retry backoff cho lỗi tạm thời, idempotency bằng khóa dựa trên payload.
+- `ui`: `UiState` và các composable `Loading/Empty/Error` + `CheckoutStateScreen` để wrap render; `Telemetry` log Crashlytics + Logcat.

--- a/android/src/main/java/com/hagotree/data/CheckoutRepository.kt
+++ b/android/src/main/java/com/hagotree/data/CheckoutRepository.kt
@@ -1,0 +1,78 @@
+package com.hagotree.data
+
+import com.hagotree.network.CheckoutRequest
+import com.hagotree.network.CheckoutResponse
+import com.hagotree.network.CheckoutService
+import java.io.IOException
+import java.util.UUID
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.retryWhen
+import okhttp3.internal.http2.StreamResetException
+import retrofit2.HttpException
+
+class CheckoutRepository(
+    private val service: CheckoutService
+) {
+
+    private val completedRequests: MutableMap<String, CheckoutResponse> = mutableMapOf()
+
+    fun checkout(cartId: String, paymentMethodId: String, totalAmount: Double): Flow<Result<CheckoutResponse>> {
+        // Idempotency: reuse the same key for identical payload to avoid duplicate charges
+        val key = buildIdempotencyKey(cartId, paymentMethodId, totalAmount)
+
+        return flow {
+            val cached = completedRequests[key]
+            if (cached != null) {
+                emit(Result.success(cached))
+                return@flow
+            }
+
+            val response = service.checkout(
+                idempotencyKey = key,
+                payload = CheckoutRequest(cartId, paymentMethodId, totalAmount)
+            )
+
+            completedRequests[key] = response
+            emit(Result.success(response))
+        }
+            .retryWhen { cause, attempt ->
+                when (mapError(cause)) {
+                    DomainError.Network, DomainError.Server -> {
+                        val delayMillis = (attempt + 1) * 1_000L
+                        delay(delayMillis)
+                        true
+                    }
+                    else -> false
+                }
+            }
+            .catchDomainErrors()
+    }
+
+    private fun buildIdempotencyKey(cartId: String, paymentMethodId: String, totalAmount: Double): String {
+        // Use a deterministic hash when possible so the same checkout payload reuses the key
+        val raw = "$cartId-$paymentMethodId-$totalAmount"
+        return UUID.nameUUIDFromBytes(raw.toByteArray()).toString()
+    }
+
+    private fun mapError(throwable: Throwable): DomainError = when (throwable) {
+        is IOException, is StreamResetException -> DomainError.Network
+        is HttpException -> when (throwable.code()) {
+            401, 403 -> DomainError.Unauthorized
+            in 500..599 -> DomainError.Server
+            else -> DomainError.Unknown(throwable)
+        }
+        is DomainError -> throwable
+        else -> DomainError.Unknown(throwable)
+    }
+
+    private fun Flow<Result<CheckoutResponse>>.catchDomainErrors(): Flow<Result<CheckoutResponse>> =
+        flow {
+            try {
+                collect { emit(it) }
+            } catch (throwable: Throwable) {
+                emit(Result.failure(mapError(throwable)))
+            }
+        }
+}

--- a/android/src/main/java/com/hagotree/data/DomainError.kt
+++ b/android/src/main/java/com/hagotree/data/DomainError.kt
@@ -1,0 +1,9 @@
+package com.hagotree.data
+
+sealed class DomainError(message: String? = null, cause: Throwable? = null) : Throwable(message, cause) {
+    object Network : DomainError("Network unavailable")
+    object Unauthorized : DomainError("User not authorized")
+    object Server : DomainError("Server error")
+    object Cancelled : DomainError("Request cancelled")
+    class Unknown(cause: Throwable? = null) : DomainError("Unexpected error", cause)
+}

--- a/android/src/main/java/com/hagotree/network/AuthInterceptor.kt
+++ b/android/src/main/java/com/hagotree/network/AuthInterceptor.kt
@@ -1,0 +1,29 @@
+package com.hagotree.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Appends the bearer token to every authenticated request. The token provider can
+ * be backed by shared preferences, DataStore or an in-memory cache depending on
+ * the app's requirements.
+ */
+class AuthInterceptor(
+    private val tokenProvider: () -> String?
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val original = chain.request()
+        val token = tokenProvider()
+
+        val authenticatedRequest = if (token.isNullOrBlank()) {
+            original
+        } else {
+            original.newBuilder()
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+        }
+
+        return chain.proceed(authenticatedRequest)
+    }
+}

--- a/android/src/main/java/com/hagotree/network/CheckoutService.kt
+++ b/android/src/main/java/com/hagotree/network/CheckoutService.kt
@@ -1,0 +1,27 @@
+package com.hagotree.network
+
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface CheckoutService {
+
+    @POST("checkout")
+    @Headers("Content-Type: application/json")
+    suspend fun checkout(
+        @Query("idempotencyKey") idempotencyKey: String,
+        @Body payload: CheckoutRequest
+    ): CheckoutResponse
+}
+
+data class CheckoutRequest(
+    val cartId: String,
+    val paymentMethodId: String,
+    val totalAmount: Double
+)
+
+data class CheckoutResponse(
+    val receiptId: String,
+    val status: String
+)

--- a/android/src/main/java/com/hagotree/network/NetworkModule.kt
+++ b/android/src/main/java/com/hagotree/network/NetworkModule.kt
@@ -1,0 +1,37 @@
+package com.hagotree.network
+
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+/**
+ * Builds Retrofit and OkHttp instances with production-friendly defaults such as timeouts,
+ * HTTP logging, and authentication injection.
+ */
+object NetworkModule {
+
+    fun provideOkHttpClient(
+        authInterceptor: AuthInterceptor,
+        networkTimeoutSeconds: Long = 30L,
+        loggingLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY
+    ): OkHttpClient {
+        val logging = HttpLoggingInterceptor().apply { level = loggingLevel }
+
+        return OkHttpClient.Builder()
+            .connectTimeout(networkTimeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(networkTimeoutSeconds, TimeUnit.SECONDS)
+            .writeTimeout(networkTimeoutSeconds, TimeUnit.SECONDS)
+            .addInterceptor(authInterceptor)
+            .addInterceptor(logging)
+            .build()
+    }
+
+    fun provideRetrofit(baseUrl: String, client: OkHttpClient): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+}

--- a/android/src/main/java/com/hagotree/ui/UiState.kt
+++ b/android/src/main/java/com/hagotree/ui/UiState.kt
@@ -1,0 +1,8 @@
+package com.hagotree.ui
+
+sealed interface UiState<out T> {
+    object Loading : UiState<Nothing>
+    object Empty : UiState<Nothing>
+    data class Error(val throwable: Throwable) : UiState<Nothing>
+    data class Data<T>(val value: T) : UiState<T>
+}

--- a/android/src/main/java/com/hagotree/ui/components/LoadStateScreens.kt
+++ b/android/src/main/java/com/hagotree/ui/components/LoadStateScreens.kt
@@ -1,0 +1,77 @@
+package com.hagotree.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hagotree.ui.UiState
+
+@Composable
+fun <T> CheckoutStateScreen(
+    uiState: UiState<T>,
+    onRetry: (() -> Unit)? = null,
+    renderData: @Composable (T) -> Unit
+) {
+    when (uiState) {
+        UiState.Loading -> LoadingScreen()
+        UiState.Empty -> EmptyScreen()
+        is UiState.Error -> ErrorScreen(uiState.throwable, onRetry)
+        is UiState.Data -> renderData(uiState.value)
+    }
+}
+
+@Composable
+fun LoadingScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = "Đang tải...", style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@Composable
+fun EmptyScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Không có dữ liệu", style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@Composable
+fun ErrorScreen(error: Throwable, onRetry: (() -> Unit)? = null) {
+    Telemetry.logNonFatal(error)
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = error.message ?: "Đã có lỗi xảy ra",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.error
+        )
+        if (onRetry != null) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = onRetry) {
+                Text(text = "Thử lại")
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/hagotree/ui/components/Telemetry.kt
+++ b/android/src/main/java/com/hagotree/ui/components/Telemetry.kt
@@ -1,0 +1,20 @@
+package com.hagotree.ui.components
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+/**
+ * Centralized telemetry helpers so UI can log both to Crashlytics and Logcat.
+ */
+object Telemetry {
+    private const val TAG = "Checkout"
+
+    fun logNonFatal(throwable: Throwable) {
+        FirebaseCrashlytics.getInstance().recordException(throwable)
+        Log.d(TAG, "Non-fatal error captured", throwable)
+    }
+
+    fun logMessage(message: String) {
+        Log.d(TAG, message)
+    }
+}


### PR DESCRIPTION
## Summary
- add Retrofit/OkHttp configuration with timeouts, logging, and authentication interceptor
- implement checkout repository Flow with idempotency, domain error mapping, and retry/backoff
- provide reusable UI load/empty/error screens with telemetry hooks for Crashlytics and Logcat

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bfde1efc8329a86f4c48f88a947f)